### PR TITLE
 将插件设置为仅在本地运行以支持在 remote / SSH / WSL / docker 情形下使用

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "version": "1.3.0",
   "publisher": "beishanyufu",
   "license": "MIT",
+  "extensionKind": [
+    "ui"
+  ],
   "keywords": [
     "IM",
     "IME",


### PR DESCRIPTION
根据文档 https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location

可以知道插件在 remote 的情况下分成两种形式生效，第一种是在本地运行的 "ui"，第二种是在 remote 端运行的 "workspace"。由于我们的插件只涉及到切换输入法、编辑文本与光标样式更改，所以只需要、也只能在本地运行。而我们的插件并没有正确地设置 extensionKind 项为 "ui"，因此自动被安装到了 remote 端，所以在这里我们需要将其安装到本地使用。

有两种解决办法，一种是用户自己加上下面的 VS Code 设置：

```json
"remote.extensionKind": {
  "draivin.hscopes": ["ui"],
  "beishanyufu.ime-and-cursor": ["ui"],
  "OrangeX4.vscode-smart-ime": ["ui"]
}
```

第二种就是我们插件作者自己加上 extensionKind 项，因此就有了这个 PR。